### PR TITLE
feature(backend): Add `jira_issue` Backend

### DIFF
--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -18,3 +18,4 @@ Developers are able to extend ``jiav`` with custom backends, refer to
    lineinfile_backend
    regexinfile_backend
    command_backend
+   jira_issue_backend

--- a/docs/source/jira_issue_backend.rst
+++ b/docs/source/jira_issue_backend.rst
@@ -1,0 +1,42 @@
+####################
+ jira_issue Backend
+####################
+
+**********
+ Overview
+**********
+
+``jiav`` can lookup a Jira issue's status to verify issues.
+
+*********
+ Example
+*********
+
+Basic scenario
+==============
+
+Verify issue if ``TEST-1`` issue is ``Done``.
+
+   .. code:: yaml
+
+      jiav:
+        verification_status: "Done"
+        verification_steps:
+          - name: Check Jira Issue
+            backend: jira_issue
+            issue: "TEST-1"
+            status: "Done"
+
+Attributes
+==========
+
+issue
+-----
+
+Jira issue ``key``.
+
+status
+------
+
+Jira issues's status. If this status is met, the invoking issue will be
+verified.

--- a/jiav/api/backends/jira_issue.py
+++ b/jiav/api/backends/jira_issue.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+from collections import namedtuple
+
+from jiav import logger
+from jiav.api.backends import BaseBackend
+from jiav.api.schemas.jira_issue import schema
+from jiav.utils.jira import JiraConnection
+
+MOCK_STEP = {"issue": "TEST-1", "status": "Done"}
+
+jiav_logger = logger.subscribe_to_logger()
+
+
+class JiraIssueBackend(BaseBackend):
+    """
+    JiraIssueBackend object
+
+    Checks that a Jira issue is in a desired status
+
+    Attributes:
+        name   - Backend name
+        schema - json_schema to be used to verify that the supplied step is
+                 valid according to the backends's requirements
+        step   - Backend excution instructions
+    """
+
+    def __init__(self):
+        self.name = "jira_issue"
+        self.schema = schema
+        self.step = MOCK_STEP
+        super().__init__(self.name, self.schema, self.step)
+
+    # Overrdie method of BaseBackend
+    def execute_backend(self):
+        """
+        Execute backend
+
+        Returns a namedtuple describing the jiav manifest execution
+        """
+        # Parse required arugments
+        issue = self.step["issue"]
+        issue_status = self.step["status"]
+        # Create a namedtuple to hold the execution result output and errors
+        result = namedtuple("result", ["successful", "output", "errors"])
+        output = list()
+        errors = list()
+        successful = False
+        # Reusing the original JiraConnection object since the class is a singleton
+        jira_connection = JiraConnection()
+        remote_issue, remote_issue_status = None, None
+        jiav_logger.debug(f"Issue: {issue}")
+        jiav_logger.debug(f"Status: {issue_status}")
+        try:
+            remote_issue = jira_connection.jira.issue(id=issue)
+            remote_issue_status = str(remote_issue.get_field("status"))
+            if remote_issue_status != issue_status:
+                jiav_logger.error(
+                    " ".join(
+                        [
+                            f"Issue '{issue}' status '{remote_issue_status}' does",
+                            f"not match the desired status '{issue_status}'",
+                        ]
+                    )
+                )
+                errors.append(
+                    (
+                        f"Issue '{issue}' status '{remote_issue_status}' does",
+                        f"not match the desired status '{issue_status}'",
+                    )
+                )
+            else:
+                successful = True
+                output.append(
+                    f"Jira issue '{issue}' is in the desired status '{issue_status}'"
+                )
+        except Exception as e:
+            jiav_logger.error(e.text)  # pyright: ignore # pylint: disable=E1101
+            errors.append(e.text)  # pyright: ignore # pylint: disable=E1101
+        self.result = result(successful, output, errors)

--- a/jiav/api/schemas/jira_issue.py
+++ b/jiav/api/schemas/jira_issue.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+schema = {
+    "type": "object",
+    "required": ["issue", "status"],
+    "properties": {"issue": {"type": "string"}, "status": {"type": "string"}},
+    "additionalProperties": False,
+}

--- a/jiav/summary.py
+++ b/jiav/summary.py
@@ -34,13 +34,16 @@ def construct_dict(title=str(), issues=list()):
     """
     dictionary = dict({title.lower(): list()})
     for issue in issues:
+        issue_assignee = (
+            issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned"
+        )
         dictionary[title].append(
             dict(
                 {
                     "issue": issue.key,
                     "summary": issue.fields.summary,
                     "status": issue.fields.status.name,
-                    "assignee": issue.fields.assignee.displayName,
+                    "assignee": issue_assignee,
                     "reporter": issue.fields.reporter.displayName,
                     "comments": issue.fields.comment.total,
                 }
@@ -98,12 +101,15 @@ def print_table(title=str(), issues=list()):
         "Comments",
     ]
     for issue in issues:
+        issue_assignee = (
+            issue.fields.assignee.displayName if issue.fields.assignee else "Unassigned"
+        )
         table.add_row(
             [
                 issue,
                 issue.fields.summary,
                 issue.fields.status,
-                (f"{issue.fields.assignee.displayName} "),
+                (f"{issue_assignee} "),
                 (f"{issue.fields.reporter.displayName} "),
                 issue.fields.comment.total,
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jiav"
-version = "0.2.1"
+version = "0.2.2"
 description = "Jira Issues Auto Verification"
 authors = ["Vadim Khitrin <me@vkhitrin.com>"]
 license = "BSD-3-Clause"


### PR DESCRIPTION
Adding a new backend `jira_issue` which allows verifying
issues based on a status of a Jira issue.

Refactor `JiraConnection` class to be a singelton that may
be reused in backends that require access to the Jira instance.

Update documentation to include `jira_backend`.

Fix summary output if an issue has no assignee.

Bump version to `0.2.2`.
