### PR TITLE
fix: Rename Variable

### DIFF
--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -39,19 +39,19 @@ command:
 
    -  -  Exit Code
       -  Description
-   -  -  `0`
+   -  -  ``0``
       -  Successful.
-   -  -  `1`
+   -  -  ``1``
       -  Issues connecting to Jira.
-   -  -  `2`
+   -  -  ``2``
       -  Issues authenticating with Jira.
-   -  -  `3`
+   -  -  ``3``
       -  JQL returned an error.
-   -  -  `4`
+   -  -  ``4``
       -  No issues returned.
-   -  -  `5`
+   -  -  ``5``
       -  Invalided manifest (when executing ``jiav validate-manifest``).
-   -  -  `6`
+   -  -  ``6``
       -  No issuers were verified.
 
 *************
@@ -91,7 +91,7 @@ Examlpe:
 Verifies issues in Jira.
 
 .. list-table::
-   :widths: 25 25 50
+   :widths: 15 25 60
    :header-rows: 1
 
    -  -  Options
@@ -122,9 +122,9 @@ Verifies issues in Jira.
       -  JQL query. NOTE: This argument is mutually exclusive with
          arguments: [issue].
 
-   -  -  ``--upload-attachment-unsafe``
+   -  -  ``--upload-attachment``
 
-      -  ``JIAV_VERIFY_UPLOAD_ATTACHMENT_UNSAFE``
+      -  ``JIAV_VERIFY_UPLOAD_ATTACHMENT``
 
       -  Uploads attachment of execution, this is not safe since all
          users who can access the ticket will be able to view it; refer
@@ -162,4 +162,4 @@ Examlpe:
 
 .. code:: bash
 
-   jiav verify --jira "http://example.com/jira" -a "<ACCESS_TOKEN>" -i 'EXAMPLE-1' --allow-public-comments --upload-attachment-unsafe
+   jiav verify --jira "http://example.com/jira" -a "<ACCESS_TOKEN>" -i 'EXAMPLE-1' --allow-public-comments --upload-attachment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jiav"
-version = "0.3.0"
+version = "0.3.1"
 description = "Jira Issues Auto Verification"
 authors = ["Vadim Khitrin <me@vkhitrin.com>"]
 license = "BSD-3-Clause"

--- a/src/jiav/cli.py
+++ b/src/jiav/cli.py
@@ -27,7 +27,7 @@ click.rich_click.OPTION_GROUPS = {
         },
         {
             "name": "Dangerous options",
-            "options": ["--upload-attachment-unsafe", "--allow-public-comments"],
+            "options": ["--upload-attachment", "--allow-public-comments"],
         },
     ]
 }
@@ -144,7 +144,7 @@ def validate_manifest(from_file: click.File) -> None:
     mutually_exclusive=["issue"],
 )
 @click.option(
-    "--upload-attachment-unsafe",
+    "--upload-attachment",
     help=(
         " ".join(
             [
@@ -195,7 +195,7 @@ def verify(
     username: str,
     issue: List[str],
     query: str,
-    upload_attachment_unsafe: bool,
+    upload_attachment: bool,
     allow_public_comments: bool,
     no_comment_on_failure: bool,
     dry_run: bool,
@@ -207,7 +207,7 @@ def verify(
     verifeid_issues: List[Issue] = []
     jiav_logger: Logger = logger.configure_logger(debug)
     # If user requested to upload attachment, warn them
-    if upload_attachment_unsafe:
+    if upload_attachment:
         jiav_logger.warn(
             "".join(
                 [
@@ -286,7 +286,7 @@ def verify(
     verifeid_issues = verification.verify_issues(
         issues=issues,
         jira_connection=jira_connection,
-        upload_attachment=upload_attachment_unsafe,
+        upload_attachment=upload_attachment,
         allow_public_comments=allow_public_comments,
         no_comment_on_failure=no_comment_on_failure,
         dry_run=dry_run,


### PR DESCRIPTION
Rename `--upload-attachment-unsafe` to `--upload-attachment`.

Bump version to `0.3.1`.
